### PR TITLE
Fix location parsing logic to allow spaces and non english characters in mission names

### DIFF
--- a/lib/missionRewards.js
+++ b/lib/missionRewards.js
@@ -27,6 +27,7 @@ module.exports = function($) {
                 if(!missionRewards[location.planet][location.location]) {
                     missionRewards[location.planet][location.location] = {
                         gameMode: location.gameMode,
+                        isEvent: location.isEvent,
                         rewards: {
                             A: [],
                             B: [],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,16 +6,23 @@ module.exports = {
     },
 
     parseLocation: function(str) {
-        const locationRegex = /([A-z]*)\/([A-z]*)\s\(([A-z]*)\)/i
+        if (str.indexOf('/') === -1) {
+            return null;
+        }
 
-        let res = str.match(locationRegex)
+        const parts = str.split('/');
+        const planet = parts[0].replace('Event:', '').trim();
+        
+        const locationAndModeParts = parts[1].split('(');
+        const location = locationAndModeParts[locationAndModeParts.length - 2].trim() + (str.trim().endsWith('Extra') ? 'Extra' : '');
 
-        if(!Array.isArray(res) || res.length != 4) return null
+        const gameMode = locationAndModeParts[locationAndModeParts.length - 1].replace(')', '').trim();
 
         return {
-            planet: res[1],
-            location: res[2],
-            gameMode: res[3]
+            planet,
+            location,
+            gameMode,
+            isEvent: str.indexOf('Event:') >= 0
         }
     },
 


### PR DESCRIPTION
This should fix some of the issues presented in
https://github.com/WFCD/warframe-drop-data/issues/1

The regex for parsing location names would not match for certain missions. When this happened, the drops for the unparseable location were added to the drops for the previous mission. I also added an event flag for missions that are considered events. That might be good information to know.

There is another issue this PR does not address. Takes Ceres/Exta as an example, that mission has 2 drop tables. The current data model might need adjustment to support a mission having 2 drop tables. 