### PR TITLE
 Fix missionRewards formatting errors.

### DIFF
--- a/generateData.js
+++ b/generateData.js
@@ -130,11 +130,11 @@ request(config.dropDataUrl, (err, res, body) => {
         for(let location of Object.keys(data.missionRewards[planet])) {
             trymkdir(path.resolve(__dirname, `data`, `missionRewards`, `${planet}`))
 
-            console.log(`Writing... /data/missionRewards/${planet}/${location.replace(':', '').replace(')', '')}.json`)
+            console.log(`Writing... /data/missionRewards/${planet}/${location.replace(':', '')}.json`)
             let missionData = Object.assign({}, data.missionRewards[planet][location])
             missionData.planet = planet
             missionData.location = location
-            fs.writeFileSync(path.resolve(__dirname, `data`, `missionRewards`, `${planet}`, `${location.replace(':', '').replace(')', '')}.json`), JSON.stringify(missionData, null, jsonFormat))
+            fs.writeFileSync(path.resolve(__dirname, `data`, `missionRewards`, `${planet}`, `${location.replace(':', '')}.json`), JSON.stringify(missionData, null, jsonFormat))
         }
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,10 +27,10 @@ module.exports = {
         let gameMode = locationAndModeParts[locationAndModeParts.length - 1].replace(')', '').trim();
 
         // Handles strings having "(Variant)".
-        if (str.trim().indexOf('(Variant)') !== -1) { location = `${location}, Variant` }
+        if (str.trim().indexOf('(Variant)') !== -1) { location = `${location} (Variant)` }
         
         // Handles strings ending with "Extra".
-        if (str.trim().endsWith('Extra')) { location = `${location}, Extra` }
+        if (str.trim().endsWith('Extra')) { location = `${location} (Extra)` }
 
         return {
             planet,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,11 +26,11 @@ module.exports = {
 
         let gameMode = locationAndModeParts[locationAndModeParts.length - 1].replace(')', '').trim();
 
-        // Handles strings ending with "Extra".
-        if (str.trim().endsWith('Extra')) { gameMode = `${gameMode}, Extra` }
-
         // Handles strings having "(Variant)".
         if (str.trim().indexOf('(Variant)') !== -1) { location = `${location}, Variant` }
+        
+        // Handles strings ending with "Extra".
+        if (str.trim().endsWith('Extra')) { location = `${location}, Extra` }
 
         return {
             planet,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,11 +12,25 @@ module.exports = {
 
         const parts = str.split('/');
         const planet = parts[0].replace('Event:', '').trim();
-        
-        const locationAndModeParts = parts[1].split('(');
-        const location = locationAndModeParts[locationAndModeParts.length - 2].trim() + (str.trim().endsWith('Extra') ? 'Extra' : '');
+        const locationCleaned = parts[1].replace('(Variant)', '').replace(/Extra$/, '').trim();
 
-        const gameMode = locationAndModeParts[locationAndModeParts.length - 1].replace(')', '').trim();
+        const locationAndModeParts = locationCleaned.split('(');
+
+        // This works in all cases where the length of locationAndModeParts is 2.
+        let location = locationAndModeParts[0].trim();
+
+        if (locationAndModeParts.length == 3) {
+            // Handles cases like "The Index: Endurance (High Risk)".
+            location = `${locationAndModeParts[0].trim()} (${locationAndModeParts[1].trim()}`;
+        }
+
+        let gameMode = locationAndModeParts[locationAndModeParts.length - 1].replace(')', '').trim();
+
+        // Handles strings ending with "Extra".
+        if (str.trim().endsWith('Extra')) { gameMode = `${gameMode}, Extra` }
+
+        // Handles strings having "(Variant)".
+        if (str.trim().indexOf('(Variant)') !== -1) { location = `${location}, Variant` }
 
         return {
             planet,


### PR DESCRIPTION
## Features
- Allow missionRewards file names to end with ")".
- Fixes cases where the mission names contains "(", like "The Index: Endurance (Low Risk)".
- Fixes cases where the location starts with "(Variant)" and add it to the end of the location.
- Fixes cases where the mission ends with "Extra", and add it to the end of the location.

## Notes
None. This pretty much just fixes the formatting and that's it.