### PR TITLE
Implement all.slim.json feature.

### DIFF
--- a/generateData.js
+++ b/generateData.js
@@ -4,7 +4,7 @@ const crypto = require("crypto")
 const path = require("path")
 const fs = require("fs")
 
-const {formatSiteData, trymkdir} = require("./lib/utils.js")
+const {formatSiteData} = require("./lib/utils.js")
 
 const config = {
     jsonMinify: true,
@@ -181,3 +181,11 @@ request(config.dropDataUrl, (err, res, body) => {
 
 
 })
+
+function trymkdir(dir) {
+    try {
+        fs.mkdirSync(dir)
+    } catch(ex) {
+        // directory already exists, probably
+    }
+}

--- a/generateData.js
+++ b/generateData.js
@@ -2,8 +2,9 @@ const cheerio = require("cheerio")
 const request = require("request")
 const crypto = require("crypto")
 const path = require("path")
-
 const fs = require("fs")
+
+const {formatSiteData, trymkdir} = require("./lib/utils.js")
 
 const config = {
     jsonMinify: true,
@@ -60,6 +61,8 @@ request(config.dropDataUrl, (err, res, body) => {
         miscItems: require("./lib/miscItems.js")($),
     }
 
+    const dropSiteData = formatSiteData(data)
+
     let date = new Date(res.headers["last-modified"]).getTime()
 
     const info = {
@@ -86,6 +89,9 @@ request(config.dropDataUrl, (err, res, body) => {
 
     console.log("Writing... /data/all.json")
     fs.writeFileSync(path.resolve(__dirname, "data", "all.json"), JSON.stringify(data, null, jsonFormat))
+
+    console.log("Writing... /data/all.slim.json")
+    fs.writeFileSync(path.resolve(__dirname, "data", "all.slim.json"), JSON.stringify(dropSiteData, null, jsonFormat))
 
     console.log("Writing... /data/info.json")
     fs.writeFileSync(path.resolve(__dirname, "data", "info.json"), JSON.stringify(info, null, jsonFormat))
@@ -175,11 +181,3 @@ request(config.dropDataUrl, (err, res, body) => {
 
 
 })
-
-function trymkdir(dir) {
-    try {
-        fs.mkdirSync(dir)
-    } catch(ex) {
-        // directory already exists, probably
-    }
-}

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
         return this.toLowerCase().indexOf(substr.toLowerCase()) > -1
     }
 
-    const CURR_SCRIPT_VERSION = 10
+    const CURR_SCRIPT_VERSION = 12
 
     function updateData(fromVersion, toVersion) {
         if (fromVersion < CURR_SCRIPT_VERSION) {
@@ -197,9 +197,7 @@
                 console.log("new hash found, re-download data")
                 localStorage.setItem("_wfinfo", JSON.stringify(data))
 
-                $.getJSON(`./data/all.json?${time}`, function(all) {
-                    all = formatData(all)
-
+                $.getJSON(`./data/all.slim.json?${time}`, function(all) {
                     localStorage.setItem("_wfdata", JSON.stringify(all))
                     onDataRetrieved(all)
                 })
@@ -267,141 +265,6 @@
         else                            { items = window._data.filter(entry => entry.item.contains(searchValue)) }
 
         fill(items, 'rarity', false, amount)
-    }
-
-    function formatData(data) {
-        let newData = []
-
-        // mission rewards
-        // planets
-        for (let planetName of Object.keys(data.missionRewards)) {
-
-            // locations
-            for (let locationName of Object.keys(data.missionRewards[planetName])) {
-
-                let location = data.missionRewards[planetName][locationName]
-
-                if (Array.isArray(location.rewards)) {
-                    let placeName = `${planetName}/${locationName} (<b>${location.gameMode}</b>)`
-
-                    for (let reward of location.rewards) {
-                        newData.push({
-                            place: placeName,
-                            item: reward.itemName,
-                            rarity: reward.rarity,
-                            chance: reward.chance
-                        })
-                    }
-                } else {
-                    for (let rotationName of Object.keys(location.rewards)) {
-                        let placeName = `${planetName}/${locationName} (<b>${location.gameMode}</b>), Rotation ${rotationName}`
-
-                        for (let reward of location.rewards[rotationName]) {
-                            newData.push({
-                                place: placeName,
-                                item: reward.itemName,
-                                rarity: reward.rarity,
-                                chance: reward.chance
-                            })
-                        }
-                    }
-                }
-            }
-        }
-
-        // blueprint locations
-        for (let item of data.blueprintLocations) {
-            for (let enemy of item.enemies) {
-                newData.push({
-                    place: enemy.enemyName,
-                    item: item.itemName,
-                    rarity: enemy.rarity,
-                    chance: (((enemy.enemyItemDropChance / 100) * (enemy.chance / 100)) * 100).toFixed(2)
-                })
-            }
-        }
-
-        // mod locations
-        for (let mod of data.modLocations) {
-            for (let enemy of mod.enemies) {
-                newData.push({
-                    place: enemy.enemyName,
-                    item: mod.modName,
-                    rarity: enemy.rarity,
-                    chance: (((enemy.enemyModDropChance / 100) * (enemy.chance / 100)) * 100).toFixed(2)
-                })
-            }
-        }
-
-        // relics
-        for (let relic of data.relics) {
-            for (let item of relic.rewards) {
-                newData.push({
-                    place: `${relic.tier} ${relic.relicName} Relic (${relic.state})`,
-                    item: item.itemName,
-                    rarity: item.rarity,
-                    chance: item.chance
-                })
-            }
-        }
-
-        // sortie rewards
-        for (let sortie of data.sortieRewards) {
-            newData.push({
-                place: "Sorties",
-                item: sortie.itemName,
-                rarity: sortie.rarity,
-                chance: sortie.chance
-            })
-        }
-
-        // transient rewards
-        for (let objective of data.transientRewards) {
-            for (let reward of objective.rewards) {
-                let rotation = ""
-
-                if (reward.rotation) {
-                    rotation = `, Rotation ${reward.rotation}`
-                }
-
-                newData.push({
-                    place: `${objective.objectiveName}${rotation}`,
-                    item: reward.itemName,
-                    rarity: reward.rarity,
-                    chance: reward.chance
-                })
-            }
-        }
-
-        // cetus bounty rewards
-        for (let bountyLevel of data.cetusBountyRewards) {
-            let levelRange = bountyLevel.bountyLevel
-
-            for (let rewardTier of Object.keys(bountyLevel.rewards)) {
-                for (let reward of bountyLevel.rewards[rewardTier]) {
-                    newData.push({
-                        place: `Earth/Cetus (<b>${levelRange}</b>), Rotation ${rewardTier}`,
-                        item: reward.itemName,
-                        rarity: reward.rarity,
-                        chance: reward.chance
-                    })
-                }
-            }
-        }
-
-        // misc enemy drops
-        for (let enemy of data.miscItems) {
-            for (let item of enemy.items) {
-                newData.push({
-                    place: enemy.enemyName,
-                    item: item.itemName,
-                    rarity: item.rarity,
-                    chance: (((enemy.enemyItemDropChance / 100) * (item.chance / 100)) * 100).toFixed(2)
-                })
-            }
-        }
-
-        return newData
     }
 
     function fill(data, sort, reverse, amount) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -211,6 +211,7 @@ module.exports = {
         // Manually clean up the rewards list.
         newData.forEach((reward) => {
             reward.place = reward.place
+                .replace('Relic (Intact)', 'Relic')
                 .replace('Derelict/', '')
                 .replace('Assassinate (<b>Assassination</b>)', 'Assassinate')
                 .replace('Defense (<b>Defense</b>)', 'Defense')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -221,11 +221,10 @@ module.exports = {
                 .replace('The Jordas Verdict C', 'Jordas Verdict')
                 .replace('The Law Of Retribution (Nightmare) C', 'Law Of Retribution (Nightmare)')
                 .replace('The Law Of Retribution C', 'Law Of Retribution')
+                .replace('Lunaro Arena', 'Lunaro')
                 .replace('Sanctuary/Elite Sanctuary Onslaught (<b>Sanctuary Onslaught</b>)', 'Elite Sanctuary Onslaught')
                 .replace('Sanctuary/Sanctuary Onslaught (<b>Sanctuary Onslaught</b>)', 'Sanctuary Onslaught')
-                .replace('/Lunaro Arena', '/Lunaro')
                 .replace(' (Extra)', '')
-                .replace(' (<b>Conclave</b>)', '')
         })
 
         return newData

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -211,14 +211,6 @@ module.exports = {
         return newData
     },
 
-    trymkdir: function(dir) {
-        try {
-            fs.mkdirSync(dir)
-        } catch(ex) {
-            // directory already exists, probably
-        }
-    },
-
     parseLocation: function(str) {
         if (str.indexOf('/') === -1) {
             return null;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,6 +47,178 @@ module.exports = {
         return true
     },
 
+    formatSiteData: function(data) {
+        let newData = []
+
+        // mission rewards
+        // planets
+        for (let planetName of Object.keys(data.missionRewards)) {
+
+            // locations
+            for (let locationName of Object.keys(data.missionRewards[planetName])) {
+
+                let location = data.missionRewards[planetName][locationName]
+
+                if (Array.isArray(location.rewards)) {
+                    let placeName = `${planetName}/${locationName} (<b>${location.gameMode}</b>)`
+
+                    for (let reward of location.rewards) {
+                        newData.push({
+                            place: placeName,
+                            item: reward.itemName,
+                            rarity: reward.rarity,
+                            chance: reward.chance
+                        })
+                    }
+                } else {
+                    for (let rotationName of Object.keys(location.rewards)) {
+                        let placeName = `${planetName}/${locationName} (<b>${location.gameMode}</b>), Rotation ${rotationName}`
+
+                        for (let reward of location.rewards[rotationName]) {
+                            newData.push({
+                                place: placeName,
+                                item: reward.itemName,
+                                rarity: reward.rarity,
+                                chance: reward.chance
+                            })
+                        }
+                    }
+                }
+            }
+        }
+
+        // key rewards
+        for (let item of data.keyRewards) {
+            if (Array.isArray(item.rewards)) {
+                let placeName = item.keyName
+
+                for (let reward of item.rewards) {
+                    newData.push({
+                        place: placeName,
+                        item: reward.itemName,
+                        rarity: reward.rarity,
+                        chance: reward.chance
+                    })
+                }
+            } else {
+                for (let rotationName of Object.keys(item.rewards)) {
+                    let placeName = `${item.keyName}, Rotation ${rotationName}`
+
+                    for (let reward of item.rewards[rotationName]) {
+                        newData.push({
+                            place: placeName,
+                            item: reward.itemName,
+                            rarity: reward.rarity,
+                            chance: reward.chance
+                        })
+                    }
+                }
+            }
+        }
+
+        // blueprint locations
+        for (let item of data.blueprintLocations) {
+            for (let enemy of item.enemies) {
+                newData.push({
+                    place: enemy.enemyName,
+                    item: item.itemName,
+                    rarity: enemy.rarity,
+                    chance: (((enemy.enemyItemDropChance / 100) * (enemy.chance / 100)) * 100).toFixed(2)
+                })
+            }
+        }
+
+        // mod locations
+        for (let mod of data.modLocations) {
+            for (let enemy of mod.enemies) {
+                newData.push({
+                    place: enemy.enemyName,
+                    item: mod.modName,
+                    rarity: enemy.rarity,
+                    chance: (((enemy.enemyModDropChance / 100) * (enemy.chance / 100)) * 100).toFixed(2)
+                })
+            }
+        }
+
+        // relics
+        for (let relic of data.relics) {
+            for (let item of relic.rewards) {
+                newData.push({
+                    place: `${relic.tier} ${relic.relicName} Relic (${relic.state})`,
+                    item: item.itemName,
+                    rarity: item.rarity,
+                    chance: item.chance
+                })
+            }
+        }
+
+        // sortie rewards
+        for (let sortie of data.sortieRewards) {
+            newData.push({
+                place: "Sorties",
+                item: sortie.itemName,
+                rarity: sortie.rarity,
+                chance: sortie.chance
+            })
+        }
+
+        // transient rewards
+        for (let objective of data.transientRewards) {
+            for (let reward of objective.rewards) {
+                let rotation = ""
+
+                if (reward.rotation) {
+                    rotation = `, Rotation ${reward.rotation}`
+                }
+
+                newData.push({
+                    place: `${objective.objectiveName}${rotation}`,
+                    item: reward.itemName,
+                    rarity: reward.rarity,
+                    chance: reward.chance
+                })
+            }
+        }
+
+        // cetus bounty rewards
+        for (let bountyLevel of data.cetusBountyRewards) {
+            let levelRange = bountyLevel.bountyLevel
+
+            for (let rewardTier of Object.keys(bountyLevel.rewards)) {
+                for (let reward of bountyLevel.rewards[rewardTier]) {
+                    newData.push({
+                        place: `Earth/Cetus (<b>${levelRange}</b>), Rotation ${rewardTier}`,
+                        item: reward.itemName,
+                        rarity: reward.rarity,
+                        chance: reward.chance
+                    })
+                }
+            }
+        }
+
+        // misc enemy drops
+        for (let enemy of data.miscItems) {
+            for (let item of enemy.items) {
+                newData.push({
+                    place: enemy.enemyName,
+                    item: item.itemName,
+                    rarity: item.rarity,
+                    chance: (((enemy.enemyItemDropChance / 100) * (item.chance / 100)) * 100).toFixed(2)
+                })
+            }
+        }
+
+        return newData
+    },
+
+    trymkdir: function(dir) {
+        try {
+            fs.mkdirSync(dir)
+        } catch(ex) {
+            // directory already exists, probably
+        }
+    },
+
     parseLocation: function(str) {
         if (str.indexOf('/') === -1) {
             return null;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -208,6 +208,26 @@ module.exports = {
             }
         }
 
+        // Manually clean up the rewards list.
+        newData.forEach((reward) => {
+            reward.place = reward.place
+                .replace('Derelict/', '')
+                .replace('Assassinate (<b>Assassination</b>)', 'Assassinate')
+                .replace('Defense (<b>Defense</b>)', 'Defense')
+                .replace('Survival (<b>Survival</b>)', 'Survival')
+                .replace('Gantulyst (Special)', 'Gantulyst (Capture)')
+                .replace('Hydrolyst (Special)', 'Hydrolyst (Capture)')
+                .replace('Teralyst (Special)', 'Teralyst (Capture)')
+                .replace('The Jordas Verdict C', 'Jordas Verdict')
+                .replace('The Law Of Retribution (Nightmare) C', 'Law Of Retribution (Nightmare)')
+                .replace('The Law Of Retribution C', 'Law Of Retribution')
+                .replace('Sanctuary/Elite Sanctuary Onslaught (<b>Sanctuary Onslaught</b>)', 'Elite Sanctuary Onslaught')
+                .replace('Sanctuary/Sanctuary Onslaught (<b>Sanctuary Onslaught</b>)', 'Sanctuary Onslaught')
+                .replace('/Lunaro Arena', '/Lunaro')
+                .replace(' (Extra)', '')
+                .replace(' (<b>Conclave</b>)', '')
+        })
+
         return newData
     },
 


### PR DESCRIPTION
### Warframe Drop Data Site Pull Request

---

**What I did:**
This moves data formatting to `generateData.js` to prevent client browsers having to format `all.json` themselves. This saves time on the client's end.

This might be an excellent time to do some refactoring, so if there's any ideas to do so, feel free to discuss (or edit if you're a collaborator). I tested this and it works. If this PR is merged, a generation should be run immediately. I didn't include `all.slim.json` as per requests in previous PRs I made.

Size difference:
**all.json**: 1769kb
**all.slim.json**: 1327kb

**Note:** This contains elements of PR #29. It doesn't depend on it but might cause conflicts if that PR is merged.

---
**Why I did it:**
As per suggestion of @TobiTenno in PR #29, it simply made sense to implement.

---
**Fixes issue (include link):**
Closes #30.

---
**Mockups, screenshots, evidence:**
This can be seen at https://senexis.github.io/warframe-drop-data.

---

**Was this an issue fix or a suggestion fulfillment?**
Suggestion fulfillment.