### PR TITLE
Update relic parser to allow for double digit relic identifiers

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -306,7 +306,7 @@ module.exports = {
     },
 
     parseRelic: function(str) {
-        const relicRegex = /([A-z]*)\s([A-Z][0-9])\sRelic\s\(([A-z]*)\)/i
+        const relicRegex = /([A-z]*)\s([A-Z][0-9]+)\sRelic\s\(([A-z]*)\)/i
 
         let res = str.match(relicRegex)
 


### PR DESCRIPTION
### Warframe Drop Data Site Pull Request

---

**What I did:**
Update relic regex parser to allow for relics with double digit identifiers (ex Neo S10 Relic)

---
**Why I did it:**
Parser was ignoring relics with double digit IDs

---
**Fixes issue (include link):**
#46

**Was this an issue fix or a suggestion fulfillment?**
Fix
