### PR TITLE
docs: update readme url

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Warframe drop data in an easier to parse format.
 
-**NOTE**: This data is parsed from [Digital Extremes official drop data website](https://n8k6e2y6.ssl.hwcdn.net/repos/hnfvc0o3jnfvc873njb03enrf56.html), no data mining was involved.
+**NOTE**: This data is parsed from [Digital Extremes official drop data website](https://www.warframe.com/droptables), no data mining was involved.
 
 ## Web UI & URL
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Warframe drop data in an easier to parse format.
 
-**NOTE**: This data is parsed from [Digital Extremes official drop data website](https://www.warframe.com/droptables), no data mining was involved.
+**NOTE**: This data is parsed from [Digital Extremes official drop data website](https://warframe-web-assets.nyc3.cdn.digitaloceanspaces.com/uploads/cms/hnfvc0o3jnfvc873njb03enrf56.html), no data mining was involved.
 
 ## Web UI & URL
 


### PR DESCRIPTION
### Warframe Drop Data Site Pull Request

---

**What I did:**
Update URL to the droptable in the README

---
**Why I did it:**
URL was incorrect and linked to a nonexistent page.

---
**Fixes issue (include link):**
Incorrect url 

---
**Mockups, screenshots, evidence:**


---

**Was this an issue fix or a suggestion fulfillment?**
