### PR TITLE
fix: profit taker rewards weren't under the correct level

### DIFF
--- a/lib/bountyRewards.js
+++ b/lib/bountyRewards.js
@@ -23,6 +23,7 @@ export default ($, id) => {
       const tmp = parseRotation(text);
       // Reset rotation when encountering a new table header.
       rotation = undefined;
+      completion = undefined;
 
       if (tmp) {
         rotation = tmp;

--- a/lib/bountyRewards.js
+++ b/lib/bountyRewards.js
@@ -8,6 +8,7 @@ export default ($, id) => {
   const bountyRewards = [];
   let bountyReward;
   let stageText;
+  let completion;
 
   if (!tbody) {
     console.error(`no table for ${id}`);
@@ -25,6 +26,8 @@ export default ($, id) => {
 
       if (tmp) {
         rotation = tmp;
+      } else if (text.includes('Completion')) {
+        completion = text;
       } else {
         if (bountyReward) {
           bountyRewards.push(bountyReward);
@@ -57,7 +60,7 @@ export default ($, id) => {
           itemName: text,
           rarity: chance.rarity,
           chance: Number(chance.chance),
-          stage: stageText,
+          stage: completion ?? stageText,
         });
       }
     }


### PR DESCRIPTION
### Warframe Drop Data Site Pull Request

---

**What I did:**
I used completion runs as stage text since profit taker has different rewards for first runs and subsequent runs 

---
**Why I did it:**
The tables for profit taker have table headers for "First Completion" and "Second completion" so because these are headers they don't contain more then one element causing the parser to create this json structure

```json
[
	{
        "id": "d30d044dd734153462ada8512ccf9cbb",
        "level": "Level 40 - 60 PROFIT-TAKER - PHASE 3",
        "rewards": {
            "a": [],
            "b": [],
            "c": []
        }
    },
    {
        "id": "e5460fddd3491fc6098d28b5b502418a",
        "level": "First Completion",
        "rewards": {
            "a": [],
            "b": [],
            "c": [... ]
        }
    },
    {
        "id": "370eee33ad52f69bcf9c47021dfeb548",
        "level": "Subsequent Completions",
        "rewards": {
            "a": [],
            "b": [],
            "c": [...]
		}
	}
]
```

---
**Fixes issue (include link):**
Describe the issue, if there was one

---
**Mockups, screenshots, evidence:**


---

**Was this an issue fix or a suggestion fulfillment?**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved bounty rewards display to ensure stage information is determined accurately. Now, when completion-related details are available, the displayed stage correctly reflects the reward’s progress, providing clearer and more consistent information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->