### PR TITLE
build: update from `hydrogen` to `jod`

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/jod

--- a/generateData.js
+++ b/generateData.js
@@ -19,7 +19,7 @@ import keyRewards from './lib/keyRewards.js';
 import bountyRewards from './lib/bountyRewards.js';
 import syndicates from './lib/syndicates.js';
 import dropByAvatar from './lib/dropByAvatar.js';
-import infoJson from './data/info.json' assert { type: 'json' };
+import infoJson from './data/info.json' with { type: 'json' };
 
 import 'colors';
 


### PR DESCRIPTION
### Warframe Drop Data Site Pull Request

---

**What I did:**
Updated the default node version from `hydrogen` to `jod`

---
**Why I did it:**
No idea, looks like there was a change with one of the deps and it breaks in hydrogen but works in jod

---
**Fixes issue (include link):**
See https://github.com/WFCD/warframe-drop-data/actions/runs/17219756075/job/48852103240

---
**Mockups, screenshots, evidence:**


---

**Was this an issue fix or a suggestion fulfillment?**
